### PR TITLE
feat : 회원가입 및 로그인 기능 ( 피드백 반영 개선 )

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    implementation group: 'org.json', name: 'json', version: '20220924'
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'

--- a/src/main/java/com/mini/hanghae99miniproject/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/mini/hanghae99miniproject/common/exception/CommonExceptionHandler.java
@@ -49,12 +49,12 @@ public class CommonExceptionHandler {
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             //
             if (fieldError.getField().equals("userid")) {
-                return new ExceptionResponse(fieldError.getField() + "는(은) 이메일 형식으로 작성하셔야 합니다.", 400);
+                return new ExceptionResponse(fieldError.getField() + " 필드는 이메일 형식으로 작성하셔야 합니다.", 400);
                 // 올바른 이메일 형식이 아닙니다
                 // 올바른 이메일 형식입니다.
             }
             //
-            return new ExceptionResponse(fieldError.getField() + "최소 8자 이상, 하나 이상의 대문자, 하나의 소문자, 하나의 숫자 및 하나의 특수 문자가 들어가야합니다.", 400);
+            return new ExceptionResponse(fieldError.getField() + " 필드는 최소 8자 이상, 하나 이상의 대문자 또는 소문자와 하나의 숫자 및 하나의 특수 문자가 들어가야합니다.", 400);
             // 숫자+영문자_특수문자 조합으로 8자리 이상 입력해주세요!
             // 안전한 비밀번호 입니다.
         }

--- a/src/main/java/com/mini/hanghae99miniproject/common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/mini/hanghae99miniproject/common/exception/CommonExceptionHandler.java
@@ -47,10 +47,16 @@ public class CommonExceptionHandler {
         BindingResult bindingResult = e.getBindingResult();
 
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
-            if (fieldError.getField().equals("username")) {
-                return new ExceptionResponse(fieldError.getField() + "(은)는 최소 4 자 및 최대 10 자 하나의 소문자, 하나의 숫자가 들어가야합니다.", 400);
+            //
+            if (fieldError.getField().equals("userid")) {
+                return new ExceptionResponse(fieldError.getField() + "는(은) 이메일 형식으로 작성하셔야 합니다.", 400);
+                // 올바른 이메일 형식이 아닙니다
+                // 올바른 이메일 형식입니다.
             }
-            return new ExceptionResponse(fieldError.getField() + "최소 8 자 및 최대 15 자, 하나 이상의 대문자, 하나의 소문자, 하나의 숫자 및 하나의 특수 문자가 들어가야합니다.", 400);
+            //
+            return new ExceptionResponse(fieldError.getField() + "최소 8자 이상, 하나 이상의 대문자, 하나의 소문자, 하나의 숫자 및 하나의 특수 문자가 들어가야합니다.", 400);
+            // 숫자+영문자_특수문자 조합으로 8자리 이상 입력해주세요!
+            // 안전한 비밀번호 입니다.
         }
         return new ExceptionResponse(INTERNAL_SERVER_ERROR_MSG);
     }

--- a/src/main/java/com/mini/hanghae99miniproject/member/controller/MemberController.java
+++ b/src/main/java/com/mini/hanghae99miniproject/member/controller/MemberController.java
@@ -1,13 +1,15 @@
 package com.mini.hanghae99miniproject.member.controller;
 
 import com.mini.hanghae99miniproject.common.response.Response;
+import com.mini.hanghae99miniproject.common.response.ResponseMessage;
 import com.mini.hanghae99miniproject.member.dto.LoginRequestDto;
 import com.mini.hanghae99miniproject.member.dto.SignupRequestDto;
 import com.mini.hanghae99miniproject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -19,13 +21,13 @@ public class MemberController {
     private final MemberService memberService;
     @PostMapping("/signup")
     public Response signup(@RequestBody @Valid SignupRequestDto signupRequestDto){
-        // json으로 보내는지 form으로 보내는지! -> @RequestBody
-        // 에러 발생 -> ExceptionResponse에서 메세지를 잘못 전달하고 있음
-        return memberService.signup(signupRequestDto);
+        memberService.signup(signupRequestDto);
+        return new Response(ResponseMessage.SIGNUP_USER_SUCCESS_MSG);
     }
 
     @PostMapping("/login")
     public Response login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
-        return memberService.login(loginRequestDto,response);
+        memberService.login(loginRequestDto,response);
+        return new Response(ResponseMessage.LOGIN_USER_SUCCESS_MSG);
     }
 }

--- a/src/main/java/com/mini/hanghae99miniproject/member/dto/LoginRequestDto.java
+++ b/src/main/java/com/mini/hanghae99miniproject/member/dto/LoginRequestDto.java
@@ -1,10 +1,8 @@
 package com.mini.hanghae99miniproject.member.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class LoginRequestDto {
     private String userid;
     private String password;

--- a/src/main/java/com/mini/hanghae99miniproject/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/mini/hanghae99miniproject/member/dto/SignupRequestDto.java
@@ -2,19 +2,19 @@ package com.mini.hanghae99miniproject.member.dto;
 
 import com.mini.hanghae99miniproject.member.entity.MemberRoleEnum;
 import lombok.Getter;
-import lombok.Setter;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @Getter
-@Setter
 public class SignupRequestDto {
     @NotBlank
     @Email
     private String userid;
     @NotBlank
     @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,}")
-    private String password; // 정리 : 비밀번호에는 공백문자 포함 안되고 최소 영문자 1자, 숫자 1자, 특수문자 1자 포함하고 8자리 이상
+    private String password; // ( 정리 : 비밀번호에는 공백문자 포함 안되고 최소 영문자 1자, 숫자 1자, 특수문자 1자 포함하고 8자리 이상 )
     // (?=.*[0-9]) => ?=(전방탐색(문법)).*(모든문자 다 탐색) :: 전방에 있는 모든문자를 제외하고( 반환이라는 의미) / [0-9](0부터 9) 1문자([0-9]가 괄호사이에 위치하기 때문)를 반환
     // (?=.*[a-zA-Z]) => ?=.* :: 전방에 있는 모든문자를 제외하고 / [a-zA-Z] 1문자를 반환
     // (?=.*\\W) => ?=.* :: 전방에 있는 모든문자를 제외하고 / \\W(특수문자) 1문자를 반환

--- a/src/main/java/com/mini/hanghae99miniproject/member/entity/MemberRoleEnum.java
+++ b/src/main/java/com/mini/hanghae99miniproject/member/entity/MemberRoleEnum.java
@@ -5,7 +5,6 @@ public enum MemberRoleEnum {
     ADMIN(Authority.ADMIN);  // 관리자 권한, MEMBER : "ROLE_ADMIN"
 
 
-    // 스트링 처리하기 위함
     private final String authority;
     MemberRoleEnum(String authority) {
         this.authority = authority;

--- a/src/main/java/com/mini/hanghae99miniproject/member/service/MemberService.java
+++ b/src/main/java/com/mini/hanghae99miniproject/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.mini.hanghae99miniproject.member.service;
 
 import com.mini.hanghae99miniproject.common.exception.ExceptionMessage;
-import com.mini.hanghae99miniproject.common.exception.ExceptionResponse;
-import com.mini.hanghae99miniproject.common.response.Response;
-import com.mini.hanghae99miniproject.common.response.ResponseMessage;
 import com.mini.hanghae99miniproject.member.dto.LoginRequestDto;
 import com.mini.hanghae99miniproject.member.dto.SignupRequestDto;
 import com.mini.hanghae99miniproject.member.entity.Member;
@@ -31,7 +28,7 @@ public class MemberService {
     private String ADMIN_TOKEN;
 
     @Transactional
-    public Response signup(SignupRequestDto signupRequestDto) {
+    public void signup(SignupRequestDto signupRequestDto) {
 
         String userid = signupRequestDto.getUserid();
         String password = passwordEncoder.encode(signupRequestDto.getPassword());
@@ -52,23 +49,19 @@ public class MemberService {
 
         Member member = new Member(userid, password, nickname, role);
         memberRepository.save(member);
-        return new Response(ResponseMessage.SIGNUP_USER_SUCCESS_MSG);
     }
 
     @Transactional
-    public Response login(LoginRequestDto loginRequestDto, HttpServletResponse response){
+    public void login(LoginRequestDto loginRequestDto, HttpServletResponse response){
+
         String inputUserid = loginRequestDto.getUserid();
-        //String inputPassword = passwordEncoder.encode(loginRequestDto.getPassword()); // 이렇게 하면, 새로운 비밀번호를 생성한다. -> 대신 passwordEncoder.mathces를 사용한다.
         String inputPassword = loginRequestDto.getPassword();
+
         Member member = memberRepository.findByUserid(inputUserid).orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.USER_NOT_FOUND_ERROR_MSG.getMsg()));
-        System.out.println("-------------------------------------------------------");
-        System.out.println("member.getPassword() = " + member.getPassword());
-        System.out.println("inputPassword = " + inputPassword);
-        System.out.println("-------------------------------------------------------");
         if(!passwordEncoder.matches(inputPassword,member.getPassword())){
             throw new IllegalArgumentException(ExceptionMessage.PASSWORDS_DO_NOT_MATCH_ERROR_MSG.getMsg());
         }
+
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(member.getUserid(),member.getRole()));
-        return new Response(ResponseMessage.LOGIN_USER_SUCCESS_MSG);
     }
 }

--- a/src/main/java/com/mini/hanghae99miniproject/post/controller/PostController.java
+++ b/src/main/java/com/mini/hanghae99miniproject/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.mini.hanghae99miniproject.post.dto.RequestPostDto;
 import com.mini.hanghae99miniproject.post.dto.ResponseAllPostDto;
 import com.mini.hanghae99miniproject.post.dto.ResponsePostDto;
 import com.mini.hanghae99miniproject.post.service.PostService;
+import com.mini.hanghae99miniproject.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/mini/hanghae99miniproject/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/mini/hanghae99miniproject/security/config/WebSecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -20,8 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
-@EnableWebSecurity // 스프링 Security 지원을 가능하게 함
-@EnableGlobalMethodSecurity(securedEnabled = true) // @Secured 어노테이션 활성화
+@EnableWebSecurity // 스프링 Security 지원설정 가능하게 함
 public class WebSecurityConfig {
 
     private final UserDetailsServiceImpl userDetailsService;
@@ -31,7 +29,6 @@ public class WebSecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -56,4 +53,5 @@ public class WebSecurityConfig {
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
+
 }

--- a/src/main/java/com/mini/hanghae99miniproject/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/mini/hanghae99miniproject/security/jwt/JwtAuthFilter.java
@@ -1,7 +1,7 @@
 package com.mini.hanghae99miniproject.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mini.hanghae99miniproject.common.response.Response;
+import com.mini.hanghae99miniproject.common.exception.ExceptionResponse;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +47,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         response.setStatus(statusCode);
         response.setContentType("application/json");
         try {
-            String json = new ObjectMapper().writeValueAsString( new Response(msg,statusCode) );
+            String json = new ObjectMapper().writeValueAsString( new ExceptionResponse(msg,statusCode) );
             response.getWriter().write(json);
         } catch (Exception e) {
             log.error(e.getMessage());


### PR DESCRIPTION
변경한 것
- implementation group: 'org.json', name: 'json', version: '20220924' 삭제
- LoginRequestDto 및 SignupRequestDto에서 @Setter삭제
- MemberRoleEnum에서 "//스트링 처리" 주석 삭제
- MemberController단에 return 형식 코드 변경
- MemberService단에 println삭제
- WebSecurityConfig에서 @EnableGlobalMethodSecurity(securedEnabled = true) 삭제
- JwtAuthFilter단에서 50번째줄 ExceptionResponse로 Response를 변경

close #20